### PR TITLE
Update k8s from 1.21 to 1.23

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ variable "digitalocean_token" {
 }
 
 data "digitalocean_kubernetes_versions" "version" {
-  version_prefix = "1.21."
+  version_prefix = "1.23."
 }
 
 locals {


### PR DESCRIPTION
DigitalOcean has deprecated k8s clusters version 1.21

Updating to version 1.23, which is well-tested.